### PR TITLE
Add mechanism to specify attack info from putflag

### DIFF
--- a/checker_protocol.md
+++ b/checker_protocol.md
@@ -48,6 +48,7 @@ Response:
 interface CheckerResultMessage {
     result: "INTERNAL_ERROR" | "OK" | "MUMBLE" | "OFFLINE";
     message: string | null;
+    attack_info?: string | null;
 }
 ```
 ### CheckerTaskMessage
@@ -62,6 +63,7 @@ The method to be executed in this task.
 * The `putflag` MUST store any credentials which are required by the `getflag` to retrieve the flag (e.g. username and password used for registering an account) in the checker's database.
 * The `putflag` MUST use the `taskChainId` (see below) as identifier in the database to store any credentials required by a later `getflag`, as this is guaranteed to be identical for any subsequent `getflag` requests for the same flag. The `taskChainId` is also guaranteed to be different for tasks in the same round for different teams and tasks for the same team in different rounds.
 * The caller MUST NOT call `putflag` with the same `flag` or `taskChainId` twice during a CTF. (Note that supporting such behavior in the checker might still be useful for testing purposes.)
+* A `putflag` MAY return a value for `attack_info` providing some identifying information the attackers may use to identify where the flag is stored in the service, such as a username in a service that doesn't provide other user enumeration capabilities.
 
 `getflag`:
 * A `getflag` request MUST check whether the flag (see the flag parameter below) placed during the previous `putflag` with the same `taskChainId` is still present in the service.
@@ -139,3 +141,7 @@ The message SHOULD provide additional information on failure cases.
 The checker MUST NOT include internal details in this message, most notably it MUST NOT include the flag or other secret information.
 
 When the `result` is `"INTERNAL_ERROR"`, the message MUST NOT be displayed publicly to participants and MAY contain secret information.
+#### attack_info
+For results from `putflag`, this is an arbitrary string that will be publicly displayed for each team and round if it is not `null`. For all other methods, this field must be unset or `null`.
+
+It SHOULD provide attackers with otherwise unavailable information required to mount an exploit retrieving this flag, such as a username.


### PR DESCRIPTION
Some services may store flags in such a way that additional information such as a username is required to reasonably mount an exploit to retrieve the flag for a given round. While some services may provide some kind of user enumeration that solves this issue, this may be difficult to provide or unfitting in the context of some services.

A possible solution to this is to provide the checker with some means of exposing this information to the players outside of the service as part of the game infrastructure. Such an approach has been employed by SAARSEC as part of SaarCTF and is detailed at the bottom of the page [here](https://ctf.saarland/setup).

This adds the ability for `putflag` requests to return some arbitrary text that would be provided to players publicly for each service, team and flag via some as of yet unspecified means.

The most likely scenario to me for the latter would seem to me to be a publicly accessible JSON file, akin to what SaarCTF is using as described above and provided similar to how `scoreboard.json` is currently generated by the engine per round. I'm unsure if specification for that would fall into this repo as well given there doesn't seem to be any such spec for `scoreboard.json` right now (though I'm guessing that may just be due to lack of time rather than an intentional omission). If so, I would draft something for that as well (though it probably wouldn't be particularly complicated anyways and presumably wouldn't interact with any other components of the game infrastructure).

I anticipate there may be some disagreement on how precisely this should be implemented, so the attached changes should be seen more as a proposal than a definitive way I would want to go forward with and I'm looking for feedback if you think there are any issues with this proposed plan.